### PR TITLE
Nissix plugin scope-packages on create-yoshi-old

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,6 @@ env.on('error', err => {
   console.error(err.message);
   process.exit(err.code || 1);
 });
-env.register(require.resolve('generator-wix-js/generators/app/index'));
+env.register(require.resolve('@wix/generator-wix-js/generators/app/index'));
 env.run(['wix-js', ...process.argv.slice(2)].join(' '), {'skip-update-check': true});
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "bundledDependencies": [
-    "generator-wix-js"
+    "@wix/generator-wix-js"
   ],
   "dependencies": {
-    "generator-wix-js": "^1.0.359",
+    "@wix/generator-wix-js": "^1.0.359",
     "yeoman-environment": "^2.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.068s



Output Log:
Migrating package "create-yoshi-old" in .


## Migration from non scope to @wix/scoped packages
> /tmp/068a88397ed0806297fe133645b06e38

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
```

